### PR TITLE
Support the delete key found below 'fn' on a full size apple keyboard

### DIFF
--- a/Classes/PXSourceList.m
+++ b/Classes/PXSourceList.m
@@ -583,7 +583,7 @@ NSString * const PXSLDeleteKeyPressedOnRowsNotification = @"PXSourceListDeleteKe
 					return;
 				}
 			}
-			else if(firstKey==NSDeleteCharacter||firstKey==NSBackspaceCharacter)
+			else if(firstKey==NSDeleteCharacter||firstKey==NSBackspaceCharacter||firstKey==0xf728)
 			{	
 				//Post the notification
 				[[NSNotificationCenter defaultCenter] postNotificationName:PXSLDeleteKeyPressedOnRowsNotification


### PR DESCRIPTION
I thought this might be some behaviour that would be good to include, as when I think about deleting from a list I will always try and use the delete key I've added support for, and usually never think to use the backspace key first.
