### PR TITLE
fix a Zeroing Weak References problem

### DIFF
--- a/PXSourceList/Internal/PXSourceListDelegateDataSourceProxy.h
+++ b/PXSourceList/Internal/PXSourceListDelegateDataSourceProxy.h
@@ -13,8 +13,8 @@
 @interface PXSourceListDelegateDataSourceProxy : NSProxy <NSOutlineViewDelegate, NSOutlineViewDataSource, PXSourceListDelegate, PXSourceListDataSource>
 
 @property (weak, nonatomic) PXSourceList *sourceList;
-@property (weak, nonatomic) id <PXSourceListDelegate> delegate;
-@property (weak, nonatomic) id <PXSourceListDataSource> dataSource;
+@property (unsafe_unretained, nonatomic) id <PXSourceListDelegate> delegate;
+@property (unsafe_unretained, nonatomic) id <PXSourceListDataSource> dataSource;
 
 - (id)initWithSourceList:(PXSourceList *)sourceList;
 


### PR DESCRIPTION
When I use PXSourceList In `osx 10.7`,  my program will crash exactly like [this problem](http://stackoverflow.com/questions/10904990/xmpp-objective-c-library-cannot-form-weak-reference-to-instance-0x7fcd4a49893) .

I make [a demo](https://github.com/CrazyCatcher/PXErrorDemo) for this problem.

Please see if that is this the right way to  solved the problem.
