### PR TITLE
Fix PXSourceListBadgeCell accessibility

### DIFF
--- a/PXSourceList/PXSourceListBadgeCell.m
+++ b/PXSourceList/PXSourceListBadgeCell.m
@@ -111,4 +111,12 @@ static const CGFloat badgeLeftAndRightPadding = 5.0;
                                            attributes:@{NSFontAttributeName: badgeFont()}];
 }
 
+- (id)accessibilityAttributeValue:(NSString *)attribute
+{
+    if ([attribute isEqualToString:NSAccessibilityValueAttribute])
+        return @(_badgeValue).description;
+    else
+        return [super accessibilityAttributeValue:attribute];
+}
+
 @end


### PR DESCRIPTION
Now in the view-based source list, instead of just "Photos", VoiceOver
reads "Photos, 264"

Provided by [A11Y LTD.](http://a11y.ltd.uk)