### PR TITLE
Fixed crash in -PXSourceList dealloc

### DIFF
--- a/PXSourceList/PXSourceList.m
+++ b/PXSourceList/PXSourceList.m
@@ -69,6 +69,7 @@ NSString * const PXSLDeleteKeyPressedOnRowsNotification = @"PXSourceListDeleteKe
 
 - (void)dealloc
 {
+    _delegateDataSourceProxy = nil;
     //Remove ourselves as the delegate and data source to be safe
     [super setDataSource:nil];
     [super setDelegate:nil];


### PR DESCRIPTION
Here's the stack trace of the crash:

```
Thread 0 Crashed:
0 libobjc.A.dylib 0x00007fff88834f3d objc_retain + 29
1 DejaLu 0x000000010b9cfa9a -PXSourceListDelegateDataSourceProxy setDelegate:
2 DejaLu 0x000000010b9e3549 -PXSourceList setDelegate:
3 AppKit 0x00007fff8baf5956 -[NSOutlineView dealloc] + 30
4 DejaLu 0x000000010b9e34ed -PXSourceList dealloc
5 libsystem_blocks.dylib 0x00007fff9d2166b1 _Block_release + 127
6 CoreFoundation 0x00007fff87cd5d0d __CFRunLoopDoBlocks + 348
7 CoreFoundation 0x00007fff87cd54ce __CFRunLoopRun + 909
8 CoreFoundation 0x00007fff87cd4ed8 CFRunLoopRunSpecific + 295
9 HIToolbox 0x00007fff8c37b935 RunCurrentEventLoopInMode + 234
10 HIToolbox 0x00007fff8c37b677 ReceiveNextEventCommon + 183
11 HIToolbox 0x00007fff8c37b5af _BlockUntilNextEventMatchingListInModeWithFilter + 70
12 AppKit 0x00007fff8b769efa _DPSNextEvent + 1066
13 AppKit 0x00007fff8b76932a -[NSApplication _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 453
14 AppKit 0x00007fff8b75de84 -[NSApplication run] + 681
15 AppKit 0x00007fff8b72746c NSApplicationMain + 1175
16 DejaLu 0x000000010b9d5435 main (main.m:39)
17 libdyld.dylib 0x00007fff98ff55ad start + 0
```
