### PR TITLE
Fixed compatibility with 10.12 Sierra

### DIFF
--- a/PXSourceList/Internal/PXSourceListDelegateDataSourceProxy.m
+++ b/PXSourceList/Internal/PXSourceListDelegateDataSourceProxy.m
@@ -146,6 +146,11 @@ static NSArray * __fastPathForwardingDataSourceMethods = nil;
     return [NSMethodSignature signatureWithObjCTypes:description.types];
 }
 
+- (BOOL) isKindOfClass:(Class)aClass
+{
+    return NO;
+}
+
 - (void)forwardInvocation:(NSInvocation *)anInvocation
 {
     SEL sourceSelector = anInvocation.selector;


### PR DESCRIPTION
PXSourceList crashes on OS X 10.12 when calling -setDataSource:

Here's the stack trace of the crash:

```
0   CoreFoundation                       0x00007fff92cf8322 ___forwarding___ + 1042
1   CoreFoundation                       0x00007fff92cf7e88 _CF_forwarding_prep_0 + 120
2   Foundation                           0x00007fff947b5699 -[NSProxy isKindOfClass:] + 64
3   AppKit                               0x00007fff91171e0c -[NSTableView _setDataSourceIvar:] + 107
4   AppKit                               0x00007fff90b3c028 -[NSOutlineView setDataSource:] + 65
5   DejaLu                               0x0000000109062bd1 -[PXSourceList setDataSource:] (PXSourceList.m:98)
```

This patch fixes it.
