### PR TITLE
Fix a crash on macOS 10.11.

### DIFF
--- a/PXSourceList/PXSourceList.m
+++ b/PXSourceList/PXSourceList.m
@@ -69,10 +69,10 @@ NSString * const PXSLDeleteKeyPressedOnRowsNotification = @"PXSourceListDeleteKe
 
 - (void)dealloc
 {
-    _delegateDataSourceProxy = nil;
     //Remove ourselves as the delegate and data source to be safe
-    [super setDataSource:nil];
     [super setDelegate:nil];
+    [super setDataSource:nil];
+    _delegateDataSourceProxy = nil;
 }
 
 


### PR DESCRIPTION
- `delegate` and `dataSource` are `assign` (not`weak`) on macOS 10.11.
- `dataSource` was set to `nil` before `delegate`, and when `dataSource` is changed `NSTableView` notifies the `delegate` about removing all rows.
- #58 introduced an issue where `_delegateDataSourceProxy` was released before setting `delegate` and `dataSource` to `nil`.
- When `NSTableView` attempted to notify the `delegate` about removing all rows it was already released, which caused crashes.